### PR TITLE
reduce min_version to 0.54.0 for Netlify compatibility

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -7,7 +7,7 @@ description = "Vex by Themefisher ported to Hugo"
 homepage = "https://themefisher.com/hugo-themes/"
 tags = ["onepage", "bootstrap", "product", "themefisher"]
 features = ["onepage", "product"]
-min_version = "0.58.0"
+min_version = "0.54.0"
 
 [author]
   name = "Themefisher"


### PR DESCRIPTION
Fixes build error on deploy to Netlify:

```
10:26:15 PM: Executing user command: hugo
10:26:15 PM: ERROR 2019/12/07 22:26:15 VEX-HUGO theme does not support Hugo version 0.54.0. Minimum version required is 0.58.0
```