### PR TITLE
Fixed "execute of template failed: template: products/single.html:28:…

### DIFF
--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -23,7 +23,7 @@
         <button class="snipcart-add-item btn btn-main mb-5" 
           data-item-id="{{.Title | urlize}}__{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}"
           data-item-name="{{.Title}}"
-          data-item-image="{{range first 1 .Params.Images}}{{. | absURL}}{{end}}"
+          data-item-image="{{with .Params.Images}} {{range first 1 . }}{{. | absURL}}{{end}}{{end}}"
           data-item-price="{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}" data-item-url="{{.Permalink}}" 
           {{ if .Params.colors }}
           data-item-custom1-name="Choose Color"


### PR DESCRIPTION
…35: executing "main" at <first 1 .Params.Images>: error calling first: both limit and seq must be provided"

In Hugo 82 the way this was done now fails site generation. I found the fix so I'm submitting a patch.